### PR TITLE
Allows to store User states in different table

### DIFF
--- a/src/ZfcUser/Authentication/Adapter/Db.php
+++ b/src/ZfcUser/Authentication/Adapter/Db.php
@@ -81,7 +81,9 @@ class Db extends AbstractAdapter implements ServiceManagerAwareInterface
 
         if ($this->getOptions()->getEnableUserState()) {
             // Don't allow user to login if state is not in allowed list
-            if (!in_array($userObject->getState(), $this->getOptions()->getAllowedLoginStates())) {
+            if (!in_array(
+                !is_object($userObject->getState()) ?: $userObject->getState()->getId(), 
+                $this->getOptions()->getAllowedLoginStates())) {
                 $e->setCode(AuthenticationResult::FAILURE_UNCATEGORIZED)
                   ->setMessages(array('A record with the supplied identity is not active.'));
                 $this->setSatisfied(false);


### PR DESCRIPTION
If enabled user states, allows to store states in other table. Edited condition to get User state id.
